### PR TITLE
Windows Com ports larger than COM9

### DIFF
--- a/gui/serialobject.pas
+++ b/gui/serialobject.pas
@@ -189,7 +189,7 @@ begin
   {$IFNDEF WINDOWS}
   FHandle := FpOpen(portName, O_RDWR or O_NOCTTY or O_NONBLOCK);
   {$ELSE}
-  FHandle := SerOpen(aPortName);
+  FHandle := SerOpen('\\.\' + aPortName);
   {$ENDIF}
 
   if {$IFNDEF WINDOWS}(FHandle < 0) {$ELSE} (FHandle = ERROR_INVALID_HANDLE) {$ENDIF} then


### PR DESCRIPTION
Hi,

  in Windows if the arduino assigned a com port larger than 9 then the app cannot open that port. A very simple fix is to prefix the port name with '\\\\.\\' .

  See, [HOWTO: Specify Serial Ports Larger than COM9](https://support.microsoft.com/en-us/topic/howto-specify-serial-ports-larger-than-com9-db9078a5-b7b6-bf00-240f-f749ebfd913e) .

regards,
  